### PR TITLE
v14.3.1 build fixes

### DIFF
--- a/GeosCore/hco_interface_gc_mod.F90
+++ b/GeosCore/hco_interface_gc_mod.F90
@@ -221,7 +221,9 @@ CONTAINS
 #ifdef MODEL_CLASSIC
     ! HEMCO Intermediate Grid specification
     USE HCO_State_GC_Mod,   ONLY : State_Grid_HCO
+#if !(defined( EXTERNAL_GRID ) || defined( EXTERNAL_FORCING ))
     USE GC_Grid_Mod,        ONLY : Compute_Scaled_Grid
+#endif
     USE HCO_Utilities_GC_Mod, ONLY : Init_IMGrid
 #endif
 
@@ -293,6 +295,7 @@ CONTAINS
        id_POPG  = Ind_('POPG_PYR')
     ENDIF
 
+#if !(defined( EXTERNAL_GRID ) || defined( EXTERNAL_FORCING ))
 #ifdef MODEL_CLASSIC
     ! Initialize the intermediate grid descriptor.
     ! To disable the HEMCO intermediate grid feature, simply set this DY, DX to
@@ -340,6 +343,7 @@ CONTAINS
       ! Intermediate grid is same as model grid. Maintain current implementation
       ! all computations about State_Grid_HCO can be skipped to save memory.
     ENDIF
+#endif
 #endif
 
     ! Create a splash page

--- a/ISORROPIA/CMakeLists.txt
+++ b/ISORROPIA/CMakeLists.txt
@@ -6,7 +6,7 @@ target_compile_options(Isorropia PRIVATE
   ""
   # NOTE: ISORROPIA probably needs to be compiled
   # with REAL*8 or else it'll crash
-  $<$<STREQUAL:"${CMAKE_Fortran_COMPILER_ID}","Intel">:-r8>
+  $<$<STREQUAL:"${CMAKE_Fortran_COMPILER_ID}","Intel">:-r8 -fixed>
   $<$<STREQUAL:"${CMAKE_Fortran_COMPILER_ID}","GNU">:-fdefault-real-8 -fdefault-double-8>
 )
 


### PR DESCRIPTION
Closes #2.

Supporting changes for https://github.com/fetch4/GISS-GC/pull/3.

The changes in this PR address GEOS-Chem build errors of the form
```
/path/to/GISS-GC/model/geos-chem/src/GEOS-Chem/GeosCore/hco_interface_gc_mod.F90(224): error #6580: Name in only-list does not exist or is not accessible.   [COMPUTE_SCALED_GRID]
    USE GC_Grid_Mod,        ONLY : Compute_Scaled_Grid
-----------------------------------^
```

Linked PRs:
https://github.com/fetch4/GISS-GC/pull/3
https://github.com/fetch4/HEMCO/pull/1