### PR TITLE
GEOS-Chem only

### DIFF
--- a/GeosCore/calc_met_mod.F90
+++ b/GeosCore/calc_met_mod.F90
@@ -25,7 +25,7 @@ MODULE CALC_MET_MOD
 !
   PUBLIC  :: AVGPOLE
   PUBLIC  :: AIRQNT
-  PUBLIC  :: GET_COSINE_SZA
+  PUBLIC  :: GET_COSINE_SZA  
   PUBLIC  :: GET_OBK
   PUBLIC  :: INTERP
   PUBLIC  :: SET_DRY_SURFACE_PRESSURE
@@ -1216,9 +1216,11 @@ CONTAINS
              ( MINUTE/1440d0 ) + ( SECOND/3600d0 )
     JD     = JULDAY( YEAR, MONTH, DDAY )             ! Current Julian date
 
+#if !defined( MODEL_GISS )    
     ! Compute cosine(SZA) quantities for the current time
     CALL COSSZA( DOY, HOUR, State_Grid, State_Met )
-
+#endif
+    
     ! Compute sum of COSSZA for HEMCO
     CALL Calc_SumCosZa ( State_Grid, State_Met )
 

--- a/GeosCore/calc_met_mod.F90
+++ b/GeosCore/calc_met_mod.F90
@@ -25,7 +25,7 @@ MODULE CALC_MET_MOD
 !
   PUBLIC  :: AVGPOLE
   PUBLIC  :: AIRQNT
-  PUBLIC  :: GET_COSINE_SZA  
+  PUBLIC  :: GET_COSINE_SZA
   PUBLIC  :: GET_OBK
   PUBLIC  :: INTERP
   PUBLIC  :: SET_DRY_SURFACE_PRESSURE
@@ -1216,11 +1216,11 @@ CONTAINS
              ( MINUTE/1440d0 ) + ( SECOND/3600d0 )
     JD     = JULDAY( YEAR, MONTH, DDAY )             ! Current Julian date
 
-#if !defined( MODEL_GISS )    
+#if !defined( MODEL_GISS )
     ! Compute cosine(SZA) quantities for the current time
     CALL COSSZA( DOY, HOUR, State_Grid, State_Met )
 #endif
-    
+
     ! Compute sum of COSSZA for HEMCO
     CALL Calc_SumCosZa ( State_Grid, State_Met )
 

--- a/GeosCore/gc_environment_mod.F90
+++ b/GeosCore/gc_environment_mod.F90
@@ -269,7 +269,7 @@ CONTAINS
                          State_Grid  = State_Grid,  &  ! Grid State
                          State_Met   = State_Met,   &  ! Meteorology State
                          RC          = RC          )   ! Success or failure?
-
+    
     ! Trap potential errors
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'Error encountered within call to "Init_State_Met"!'
@@ -480,6 +480,7 @@ CONTAINS
        RETURN
     ENDIF
 
+#if ! defined( MODEL_GISS )
     !=======================================================================
     ! Initialize the hybrid pressure module.  Define Ap and Bp.
     !=======================================================================
@@ -489,7 +490,8 @@ CONTAINS
        CALL GC_Error( ErrMsg, RC, ThisLoc )
        RETURN
     ENDIF
-
+#endif
+    
     !=======================================================================
     ! Call setup routines for drydep
     !=======================================================================

--- a/GeosCore/gc_environment_mod.F90
+++ b/GeosCore/gc_environment_mod.F90
@@ -269,7 +269,7 @@ CONTAINS
                          State_Grid  = State_Grid,  &  ! Grid State
                          State_Met   = State_Met,   &  ! Meteorology State
                          RC          = RC          )   ! Success or failure?
-    
+
     ! Trap potential errors
     IF ( RC /= GC_SUCCESS ) THEN
        ErrMsg = 'Error encountered within call to "Init_State_Met"!'
@@ -480,7 +480,7 @@ CONTAINS
        RETURN
     ENDIF
 
-#if ! defined( MODEL_GISS )
+#if !defined( MODEL_GISS )
     !=======================================================================
     ! Initialize the hybrid pressure module.  Define Ap and Bp.
     !=======================================================================
@@ -491,7 +491,7 @@ CONTAINS
        RETURN
     ENDIF
 #endif
-    
+
     !=======================================================================
     ! Call setup routines for drydep
     !=======================================================================

--- a/GeosCore/hco_interface_gc_mod.F90
+++ b/GeosCore/hco_interface_gc_mod.F90
@@ -965,7 +965,7 @@ CONTAINS
        ENDIF
     ENDIF
 
-#if !defined( ESMF_ ) && !defined( MODEL_WRF )
+#if !defined( ESMF_ ) && !defined( MODEL_WRF ) && !defined( MODEL_GISS )
     ! Check if HEMCO has already been called for this timestep
     IF ( ( Phase == 1 ) .and. ( GET_TAU() == PrevTAU ) .and. Input_Opt%amIRoot ) THEN
        Print*, 'HEMCO already called for this timestep. Returning.'


### PR DESCRIPTION
Closes #12.

Includes changes from https://github.com/geoschem/geos-chem/pull/2499.

Just a few minor pre-processor modifications to ensure we can run GEOS-Chem under GCClassic as well as under GISS-GC.